### PR TITLE
Optimising entity checks, enable command blocks

### DIFF
--- a/src/main/java/me/teakivy/eggfix/ChunkLoadEvent.java
+++ b/src/main/java/me/teakivy/eggfix/ChunkLoadEvent.java
@@ -15,14 +15,11 @@ public class ChunkLoadEvent implements Listener {
     @EventHandler
     public void onLoad(org.bukkit.event.world.ChunkLoadEvent event) {
         Chunk chunk = event.getChunk();
-        for (Entity entity : chunk.getEntities()) {
+        for (LivingEntity entity : chunk.getLivingEntities()) {
             if (entity.getType() != EntityType.PLAYER) {
-                if (entity instanceof LivingEntity) {
-                    LivingEntity lentity = (LivingEntity) entity;
-                    if (Objects.requireNonNull(lentity.getEquipment()).getItemInMainHand().getType() == Material.EGG) {
-                        lentity.remove();
-                    }
-                }
+				if (Objects.requireNonNull(entity.getEquipment()).getItemInMainHand().getType() == Material.EGG) {
+					entity.remove();
+				}
             }
         }
     }

--- a/src/main/java/me/teakivy/eggfix/Main.java
+++ b/src/main/java/me/teakivy/eggfix/Main.java
@@ -40,33 +40,37 @@ public final class Main extends JavaPlugin implements Listener {
         }
     }
 
-
-
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 
         if (command.getName().equalsIgnoreCase("eggfix")) {
-            if (!(sender instanceof Player)) {
-                sender.sendMessage(ChatColor.RED + "You must be a player to use this command!");
-                return true;
-            }
-            if (!sender.isOp()) {
-                sender.sendMessage(ChatColor.RED + "You need to have OP to run this command!");
-                return true;
-            }
-            int count = 0;
-            for (Entity entity : ((Player) sender).getWorld().getEntities()) {
-                if (entity.getType() != EntityType.PLAYER) {
-                    if (entity instanceof LivingEntity) {
-                        LivingEntity lentity = (LivingEntity) entity;
-                        if (Objects.requireNonNull(lentity.getEquipment()).getItemInMainHand().getType() == Material.EGG) {
-                            lentity.remove();
-                            count++;
-                        }
-                    }
-                }
-            }
-            sender.sendMessage("\n" + ChatColor.GRAY + "---------------" + "\n" + ChatColor.YELLOW + "Removed " + ChatColor.GOLD.toString() + ChatColor.BOLD + count + ChatColor.RESET.toString() + ChatColor.YELLOW + " Mobs Holding Eggs!" + "\n" + ChatColor.GRAY + "---------------" + "\n");
+			if(sender instanceof Player) {
+
+				if(!sender.isOp()) {
+					sender.sendMessage(ChatColor.RED + "You need to have OP to run this command!");
+                	return true;
+				}
+			}
+
+			int count = 0;
+
+			for(World world : Bukkit.getWorlds()) {
+				for(LivingEntity entity : world.getLivingEntities()) {
+					if (entity.getType() != EntityType.PLAYER && Objects.requireNonNull(entity.getEquipment()).getItemInMainHand().getType() == Material.EGG) {
+						entity.remove();
+						count++;
+					}
+				}
+			}
+
+			sender.sendMessage(
+				"\n" + ChatColor.GRAY + "---------------" + "\n" + 
+				ChatColor.YELLOW + "Removed " + 
+				ChatColor.GOLD.toString() + ChatColor.BOLD + count + 
+				ChatColor.RESET.toString() + ChatColor.YELLOW + " Mobs Holding Eggs!" + "\n" + 
+				ChatColor.GRAY + "---------------" + "\n");
+
+			return true;
 
         }
 


### PR DESCRIPTION
I made some changes to the code that enables command blocks to use the eggfix function.
Along the way I also made optimisations to how entities are checked, such that it is now looping through only LivingEntities instead of all entities and doing an equality check.

Command block output needs to be properly modified - currently the long output just looks like '---------'.

It has been tried and tested, so I can confirm that the changes still function as expected.